### PR TITLE
Deploy module "se.jbee.inject" via JitPack

### DIFF
--- a/.bach/src/Build.java
+++ b/.bach/src/Build.java
@@ -7,21 +7,21 @@
 // default package
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.spi.ToolProvider;
 
-/**
- * Silk's build program.
- */
+/** Silk's build program. */
 class Build {
-  public static void main(String... args) {
+  public static void main(String... args) throws Exception {
+    var version = "19.1-ea";
     var silk =
         Bach.Project.builder()
             .title("Silk DI")
-            .version("1-ea")
+            .version(version)
             .setRealms(List.of(core(), example(), test()))
             .requires("org.hamcrest") // By junit at runtime.
             .requires("org.junit.vintage.engine") // Discovers and executes JUnit 3/4 tests.
@@ -30,14 +30,77 @@ class Build {
 
     Bach.of(silk).build();
 
+    generateAndPackageApiDocumentation(version);
+    generateMavenPomXml(version);
+  }
+
+  private static void generateAndPackageApiDocumentation(String version) {
     var javadoc = ToolProvider.findFirst("javadoc").orElseThrow();
-    javadoc.run(System.out, System.err,
-        "--module", "se.jbee.inject",
-        "--module-source-path", "se.jbee.inject=src/core" + File.pathSeparator +  "src/core-module",
-        "-d", ".bach/workspace/documentation/api",
-        "-encoding", "UTF-8",
+    javadoc.run(
+        System.out,
+        System.err,
+        "--module",
+        "se.jbee.inject",
+        "--module-source-path",
+        "se.jbee.inject=src/core" + File.pathSeparator + "src/core-module",
+        "-d",
+        ".bach/workspace/documentation/api",
+        "-encoding",
+        "UTF-8",
         "-quiet",
         "-Xdoclint:none");
+
+    var jar = ToolProvider.findFirst("jar").orElseThrow();
+    jar.run(
+        System.out,
+        System.err,
+        "--create",
+        "--file",
+        ".bach/workspace/documentation/silk-" + version + "-javadoc.jar",
+        "--no-manifest",
+        "-C",
+        ".bach/workspace/documentation/api",
+        ".");
+  }
+
+  private static void generateMavenPomXml(String version) throws Exception {
+    Files.write(
+        Path.of(".bach/workspace/se.jbee.inject@19.1-ea.pom.xml"),
+        List.of(
+            "<?xml version='1.0' encoding='UTF-8'?>",
+            "<project xmlns='http://maven.apache.org/POM/4.0.0'",
+            "    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'",
+            "    xsi:schemaLocation='http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd'>",
+            "    <modelVersion>4.0.0</modelVersion>",
+            "",
+            "    <groupId>se.jbee</groupId>",
+            "    <artifactId>se.jbee.inject</artifactId>",
+            "    <version>" + version + "</version>",
+            "",
+            "    <name>Silk DI</name>",
+            "    <description>Silk Java dependency injection framework</description>",
+            "",
+            "    <url>http://www.silkdi.com</url>",
+            "   <licenses>",
+            "        <license>",
+            "            <name>Apache License, Version 2.0</name>",
+            "            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>",
+            "            <distribution>repo</distribution>",
+            "        </license>",
+            "    </licenses>",
+            "    <scm>",
+            "        <url>https://github.com/jbee/silk</url>",
+            "        <connection>https://github.com/jbee/silk.git</connection>",
+            "   </scm>",
+            "",
+            "    <developers>",
+            "        <developer>",
+            "            <id>jan</id>",
+            "            <name>Jan Bernitt</name>",
+            "            <email>jan@jbee.se</email>",
+            "        </developer>",
+            "    </developers>",
+            "</project>"));
   }
 
   private static Bach.Project.Realm core() {

--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,16 @@
+before_install:
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source install-jdk.sh --feature 14
+  - jshell --version
+
+install:
+  - unset JAVA_TOOL_OPTIONS
+  - jshell -R-Debug https://sormuras.de/bach/build
+  - VERSION="19.1-ea"
+  - MODULE_AND_VERSION="se.jbee.inject@${VERSION}"
+  - OUT=".bach/workspace"
+  - POM_FILE="-DpomFile=${OUT}/${MODULE_AND_VERSION}.pom.xml"
+  - JAR_FILE="-Dfile=${OUT}/modules/core/${MODULE_AND_VERSION}.jar"
+  - SRC_FILE="-Dsources=${OUT}/sources/core/${MODULE_AND_VERSION}-sources.jar"
+  - API_FILE="-Djavadoc=${OUT}/documentation/silk-${VERSION}-javadoc.jar"
+  - mvn install:install-file ${POM_FILE} ${JAR_FILE} ${SRC_FILE} ${API_FILE}


### PR DESCRIPTION
- Set Silk DI's version to "19.1-ea"
- Generate consumer pom.xml
- Add JitPack configuration file

Initial results from this branch:
- Usage: https://jitpack.io/#sormuras/silk/jitpack-SNAPSHOT
- Build log: https://jitpack.io/com/github/sormuras/silk/jitpack-SNAPSHOT/build.log
- API documentation: https://javadoc.jitpack.io/com/github/sormuras/silk/jitpack-SNAPSHOT/javadoc